### PR TITLE
Add FLAN-T5

### DIFF
--- a/TransformerCatalog.bbl
+++ b/TransformerCatalog.bbl
@@ -194,6 +194,17 @@ Zhengyan Zhang, Xu~Han, Zhiyuan Liu, Xin Jiang, Maosong Sun, and Qun Liu.
 \newblock Ernie: Enhanced language representation with informative entities.
 \newblock {\em arXiv preprint arXiv:1905.07129}, 2019.
 
+\bibitem{chung2022flan}
+Hyung~Won Chung, Le~Hou, Shayne Longpre, Barret Zoph, Yi~Tay, William Fedus,
+  Yunxuan Li, Xuezhi Wang, Mostafa Dehghani, Siddhartha Brahma, Albert Webson,
+  Shixiang~Shane Gu, Zhuyun Dai, Mirac Suzgun, Xinyun Chen, Aakanksha
+  Chowdhery, Alex Castro-Ros, Marie Pellat, Kevin Robinson, Dasha Valter,
+  Sharan Narang, Gaurav Mishra, Adams Yu, Vincent Zhao, Yanping Huang, Andrew
+  Dai, Hongkun Yu, Slav Petrov, Ed~H. Chi, Jeff Dean, Jacob Devlin, Adam
+  Roberts, Denny Zhou, Quoc~V. Le, and Jason Wei.
+\newblock Scaling instruction-finetuned language models.
+\newblock {\em arXiv preprint arXiv:2210.11416}, 2022.
+
 \bibitem{alayrac2022flamingo}
 Jean-Baptiste Alayrac, Jeff Donahue, Pauline Luc, Antoine Miech, Iain Barr,
   Yana Hasson, Karel Lenc, Arthur Mensch, Katie Millican, Malcolm Reynolds,

--- a/TransformerCatalog.tex
+++ b/TransformerCatalog.tex
@@ -515,7 +515,22 @@ Finally, here is the full list view that might be easier to follow along in some
                 \item \textbf{Corpus:} English Wikipedia + Wikidata for entitites (note that they initialize model to original BERT parameter values
                 \item \textbf{Lab:} Various Chinese institutions
             \end{itemize} 
-            
+
+\subsubsection{FLAN T5}
+
+            \begin{itemize}
+                \item \textbf{Reference:}\footnote{\url{https://huggingface.co/docs/transformers/model_doc/flan-t5}}\cite{chung2022flan}
+                \item \textbf{Family:} T5
+                \item \textbf{Pretraining Architecture:} Encoder/Decoder
+                \item \textbf{Pretraining Task:} DAE
+                \item \textbf{Extension:} Same as T5 with additional general instruction finetuning
+                \item \textbf{Application:} General language tasks including machine translation, question answering, abstractive summarization, and text classification
+                \item \textbf{Date (of first known publication):} 10/2022
+                \item \textbf{Num. Params:} 11 B (up to)
+                \item \textbf{Corpus:} Colossal Clean Crawled Corpus (C4) — Cleaned up version of the Common Crawl dataset — 750 GB, Flan
+                \item \textbf{Lab:} Google
+            \end{itemize}
+
 \subsubsection{Flamingo}
 
             \begin{itemize}

--- a/references.bib
+++ b/references.bib
@@ -483,6 +483,13 @@
   publisher={JMLRORG}
 }
 
+@article{chung2022flan,
+  title={Scaling Instruction-Finetuned Language Models},
+  author={Chung, Hyung Won and Hou, Le and Longpre, Shayne and Zoph, Barret and Tay, Yi and Fedus, William and Li, Yunxuan and Wang, Xuezhi and Dehghani, Mostafa and Brahma, Siddhartha and Webson, Albert and Gu, Shixiang Shane and Dai, Zhuyun and Suzgun, Mirac and Chen, Xinyun and Chowdhery, Aakanksha and Castro-Ros, Alex and Pellat, Marie and Robinson, Kevin and Valter, Dasha and Narang, Sharan and Mishra, Gaurav and Yu, Adams and Zhao, Vincent and Huang, Yanping and Dai, Andrew and Yu, Hongkun and Petrov, Slav and Chi, Ed H. and Dean, Jeff and Devlin, Jacob and Roberts, Adam and Zhou, Denny and Le, Quoc V. and Wei, Jason},
+  journal={arXiv preprint arXiv:2210.11416},
+  year={2022}
+}
+
 @article{janner2021offline,
   title={Offline reinforcement learning as one big sequence modeling problem},
   author={Janner, Michael and Li, Qiyang and Levine, Sergey},


### PR DESCRIPTION
This change adds the instruction fine-tuned FLAN-T5 model to the model list.