### PR TITLE
Adding Facebook's Atlas

### DIFF
--- a/TransformerCatalog.bbl
+++ b/TransformerCatalog.bbl
@@ -459,4 +459,10 @@ Tianyang Lin, Yuxin Wang, Xiangyang Liu, and Xipeng Qiu.
 \newblock A survey of transformers.
 \newblock {\em AI Open}, 2022.
 
+\bibtem{izacard2022few}
+Izacard, Gautier and Lewis, Patrick and Lomeli, Maria and Hosseini, Lucas and Petroni, Fabio and Schick, Timo and Dwivedi-Yu, Jane and Joulin, Armand and Riedel, Sebastian and Grave, Edouard
+\newblock Few-shot learning with retrieval augmented language models
+\newblock {\em arXiv preprint arXiv:2208.03299}, 2022
+
+
 \end{thebibliography}

--- a/TransformerCatalog.tex
+++ b/TransformerCatalog.tex
@@ -250,6 +250,20 @@ Finally, here is the full list view that might be easier to follow along in some
                 \item \textbf{Lab:}Anthropic
             \end{itemize}
 
+\subsubsection{Atlas}
+            \begin{itemize}
+                \item \textbf{Reference:}\cite{izacard2022few}
+                \item \textbf{Family:} T5
+                \item \textbf{Pretraining Architecture:} Encoder/Decoder
+                \item \textbf{Pretraining Task:} MLM
+                \item \textbf{Extension: Atlas is a retrieval-augmented language model pretrained on unlabeled data that exhibits few-shot abilities on knowledge-intensive tasks, such as Q&A and fact-checking}
+                \item \textbf{Application: Question-answering, knowledge-search via Q&A}
+                \item \textbf{Date (of first known publication):} 11/2022
+                \item \textbf{Num. Params:} 11B
+                \item \textbf{Corpus:} English Wikipedia
+                \item \textbf{Lab:} Facebook
+            \end{itemize}
+
 \subsubsection{BART}
             \begin{itemize}
                 \item \textbf{Reference:}\footnote{\url{https://huggingface.co/docs/transformers/model_doc/bart}}\cite{lewis2019bart}

--- a/references.bib
+++ b/references.bib
@@ -551,3 +551,10 @@
   journal={arXiv preprint arXiv:2212.06817},
   year = {2022}
 }
+
+@article{izacard2022few,
+  title={Few-shot learning with retrieval augmented language models},
+  author={Izacard, Gautier and Lewis, Patrick and Lomeli, Maria and Hosseini, Lucas and Petroni, Fabio and Schick, Timo and Dwivedi-Yu, Jane and Joulin, Armand and Riedel, Sebastian and Grave, Edouard},
+  journal={arXiv preprint arXiv:2208.03299},
+  year={2022}
+}


### PR DESCRIPTION
Adding references for https://research.facebook.com/blog/2023/1/atlas-few-shot-learning-with-retrieval-augmented-language-models/